### PR TITLE
Add random oracle to pack acc

### DIFF
--- a/metaplex-tests/tests/activate.rs
+++ b/metaplex-tests/tests/activate.rs
@@ -34,6 +34,9 @@ async fn setup() -> (
     let uri = String::from("some link to storage");
     let description = String::from("Pack description");
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -48,6 +51,7 @@ async fn setup() -> (
                 redeem_start_date: None,
                 redeem_end_date: None,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/add_card_to_pack.rs
+++ b/metaplex-tests/tests/add_card_to_pack.rs
@@ -33,6 +33,9 @@ async fn setup(
     let uri = String::from("some link to storage");
     let description = String::from("Pack description");
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -47,6 +50,7 @@ async fn setup(
                 redeem_start_date: None,
                 redeem_end_date: None,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/add_voucher_to_pack.rs
+++ b/metaplex-tests/tests/add_voucher_to_pack.rs
@@ -32,6 +32,9 @@ async fn setup() -> (
     let uri = String::from("some link to storage");
     let description = String::from("Pack description");
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -46,6 +49,7 @@ async fn setup() -> (
                 redeem_start_date: None,
                 redeem_end_date: None,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/claim_card.rs
+++ b/metaplex-tests/tests/claim_card.rs
@@ -75,7 +75,7 @@ async fn success_fixed_probability() {
     let store_key = create_store(&mut context, &store_admin, true)
         .await
         .unwrap();
-    
+
     let mut test_randomness_oracle = TestRandomnessOracle::new();
     test_randomness_oracle.init(&mut context).await.unwrap();
 

--- a/metaplex-tests/tests/claim_card.rs
+++ b/metaplex-tests/tests/claim_card.rs
@@ -75,6 +75,9 @@ async fn success_fixed_probability() {
     let store_key = create_store(&mut context, &store_admin, true)
         .await
         .unwrap();
+    
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
 
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
@@ -90,6 +93,7 @@ async fn success_fixed_probability() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -166,8 +170,6 @@ async fn success_fixed_probability() {
     let new_mint = Keypair::new();
     let new_mint_token_acc = Keypair::new();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -244,6 +246,9 @@ async fn success_max_supply_probability() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -258,6 +263,7 @@ async fn success_max_supply_probability() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -330,8 +336,7 @@ async fn success_max_supply_probability() {
 
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
+
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     context.warp_to_slot(3).unwrap();
@@ -405,6 +410,9 @@ async fn success_claim_two_same_cards() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -419,6 +427,7 @@ async fn success_claim_two_same_cards() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -500,8 +509,6 @@ async fn success_claim_two_same_cards() {
     let new_mint1 = Keypair::new();
     let new_mint_token_acc1 = Keypair::new();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -597,6 +604,9 @@ async fn success_claim_decrement_redeem_cards() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -611,6 +621,7 @@ async fn success_claim_decrement_redeem_cards() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -692,8 +703,6 @@ async fn success_claim_decrement_redeem_cards() {
     let new_mint1 = Keypair::new();
     let new_mint_token_acc1 = Keypair::new();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -804,6 +813,9 @@ async fn success_claim_two_indexes() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -818,6 +830,7 @@ async fn success_claim_two_indexes() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -920,8 +933,6 @@ async fn success_claim_two_indexes() {
     let new_mint = Keypair::new();
     let new_mint_token_acc = Keypair::new();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -1014,6 +1025,9 @@ async fn success_claim_after_redeem_end_date() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -1028,6 +1042,7 @@ async fn success_claim_after_redeem_end_date() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -1099,8 +1114,6 @@ async fn success_claim_after_redeem_end_date() {
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     context.warp_to_slot(3).unwrap();
@@ -1172,6 +1185,9 @@ async fn fail_wrong_user_wallet() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -1186,6 +1202,7 @@ async fn fail_wrong_user_wallet() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -1258,8 +1275,7 @@ async fn fail_wrong_user_wallet() {
 
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
+
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -1419,6 +1435,9 @@ async fn fail_claim_twice() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -1433,6 +1452,7 @@ async fn fail_claim_twice() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -1506,8 +1526,6 @@ async fn fail_claim_twice() {
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     context.warp_to_slot(3).unwrap();

--- a/metaplex-tests/tests/clean_up.rs
+++ b/metaplex-tests/tests/clean_up.rs
@@ -61,6 +61,9 @@ async fn success_clean_up_change() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -75,6 +78,7 @@ async fn success_clean_up_change() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -147,8 +151,6 @@ async fn success_clean_up_change() {
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -208,6 +210,9 @@ async fn success_clean_up_sort() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -222,6 +227,7 @@ async fn success_clean_up_sort() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/close_pack.rs
+++ b/metaplex-tests/tests/close_pack.rs
@@ -32,6 +32,9 @@ async fn setup() -> (
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -46,6 +49,7 @@ async fn setup() -> (
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/deactivate.rs
+++ b/metaplex-tests/tests/deactivate.rs
@@ -39,6 +39,9 @@ async fn setup() -> (
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -53,6 +56,7 @@ async fn setup() -> (
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/delete_pack.rs
+++ b/metaplex-tests/tests/delete_pack.rs
@@ -39,6 +39,9 @@ async fn setup() -> (
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -53,6 +56,7 @@ async fn setup() -> (
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/delete_pack_card.rs
+++ b/metaplex-tests/tests/delete_pack_card.rs
@@ -40,6 +40,9 @@ async fn setup() -> (
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -54,6 +57,7 @@ async fn setup() -> (
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/delete_pack_voucher.rs
+++ b/metaplex-tests/tests/delete_pack_voucher.rs
@@ -40,6 +40,9 @@ async fn setup() -> (
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -54,6 +57,7 @@ async fn setup() -> (
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/edit_pack.rs
+++ b/metaplex-tests/tests/edit_pack.rs
@@ -36,6 +36,9 @@ async fn setup(
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -50,6 +53,7 @@ async fn setup(
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/init_pack_set.rs
+++ b/metaplex-tests/tests/init_pack_set.rs
@@ -9,7 +9,7 @@ use num_traits::FromPrimitive;
 use solana_program::instruction::InstructionError;
 use solana_program_test::*;
 use solana_sdk::{
-    signer::keypair::Keypair, transaction::TransactionError, transport::TransportError,
+    signer::keypair::Keypair, transaction::TransactionError, transport::TransportError, signature::Signer,
 };
 use utils::*;
 
@@ -31,6 +31,9 @@ async fn success() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -45,6 +48,7 @@ async fn success() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -81,6 +85,9 @@ async fn fail() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     let result = test_pack_set
         .init(
@@ -95,6 +102,7 @@ async fn fail() {
                 redeem_start_date,
                 redeem_end_date: redeem_start_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await;
 

--- a/metaplex-tests/tests/init_pack_set.rs
+++ b/metaplex-tests/tests/init_pack_set.rs
@@ -9,7 +9,8 @@ use num_traits::FromPrimitive;
 use solana_program::instruction::InstructionError;
 use solana_program_test::*;
 use solana_sdk::{
-    signer::keypair::Keypair, transaction::TransactionError, transport::TransportError, signature::Signer,
+    signature::Signer, signer::keypair::Keypair, transaction::TransactionError,
+    transport::TransportError,
 };
 use utils::*;
 

--- a/metaplex-tests/tests/request_card_to_redeem.rs
+++ b/metaplex-tests/tests/request_card_to_redeem.rs
@@ -68,6 +68,9 @@ async fn success() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -82,6 +85,7 @@ async fn success() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -153,8 +157,7 @@ async fn success() {
 
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
+
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -204,6 +207,9 @@ async fn success_two_cards() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -218,6 +224,7 @@ async fn success_two_cards() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -310,8 +317,6 @@ async fn success_two_cards() {
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -362,6 +367,9 @@ async fn fail_request_without_clean_up() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -376,6 +384,7 @@ async fn fail_request_without_clean_up() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -447,8 +456,7 @@ async fn fail_request_without_clean_up() {
 
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
+
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     test_pack_set
@@ -508,6 +516,9 @@ async fn fail_request_after_end_date() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -522,6 +533,7 @@ async fn fail_request_after_end_date() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -612,8 +624,6 @@ async fn fail_request_after_end_date() {
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     // Wait until we reach over `redeem_end_date` timestamp
@@ -661,6 +671,9 @@ async fn fail_request_with_invalid_voucher() {
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -675,6 +688,7 @@ async fn fail_request_with_invalid_voucher() {
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();
@@ -765,8 +779,6 @@ async fn fail_request_with_invalid_voucher() {
     test_pack_set.activate(&mut context).await.unwrap();
     test_pack_set.clean_up(&mut context).await.unwrap();
 
-    let mut test_randomness_oracle = TestRandomnessOracle::new();
-    test_randomness_oracle.init(&mut context).await.unwrap();
     test_randomness_oracle.update(&mut context).await.unwrap();
 
     // Wait until we reach over `redeem_end_date` timestamp

--- a/metaplex-tests/tests/transfer_pack_authority.rs
+++ b/metaplex-tests/tests/transfer_pack_authority.rs
@@ -40,6 +40,9 @@ async fn setup() -> (
         .await
         .unwrap();
 
+    let mut test_randomness_oracle = TestRandomnessOracle::new();
+    test_randomness_oracle.init(&mut context).await.unwrap();
+
     let test_pack_set = TestPackSet::new(store_key);
     test_pack_set
         .init(
@@ -54,6 +57,7 @@ async fn setup() -> (
                 redeem_start_date,
                 redeem_end_date,
             },
+            &test_randomness_oracle.keypair.pubkey(),
         )
         .await
         .unwrap();

--- a/metaplex-tests/tests/utils/pack_set.rs
+++ b/metaplex-tests/tests/utils/pack_set.rs
@@ -40,6 +40,7 @@ impl TestPackSet {
         &self,
         context: &mut ProgramTestContext,
         args: instruction::InitPackSetArgs,
+        randomness_oracle: &Pubkey,
     ) -> transport::Result<()> {
         create_account::<PackSet>(context, &self.keypair, &metaplex_nft_packs::id()).await?;
 
@@ -56,6 +57,7 @@ impl TestPackSet {
                     &self.keypair.pubkey(),
                     &self.authority.pubkey(),
                     &self.store,
+                    randomness_oracle,
                     &self.minting_authority.pubkey(),
                     args,
                 ),

--- a/nft-packs/src/instruction.rs
+++ b/nft-packs/src/instruction.rs
@@ -87,6 +87,7 @@ pub enum NFTPacksInstruction {
     /// - write                          pack_set
     /// - signer                         authority
     /// - read                           store
+    /// - read                           random_oracle
     /// - read                           Rent account
     /// - read                           Clock account
     /// - read                           whitelisted_creator. Optional key
@@ -319,6 +320,7 @@ pub fn init_pack(
     pack_set: &Pubkey,
     authority: &Pubkey,
     store: &Pubkey,
+    random_oracle: &Pubkey,
     whitelisted_creator: &Pubkey,
     args: InitPackSetArgs,
 ) -> Instruction {
@@ -326,6 +328,7 @@ pub fn init_pack(
         AccountMeta::new(*pack_set, false),
         AccountMeta::new_readonly(*authority, true),
         AccountMeta::new_readonly(*store, false),
+        AccountMeta::new_readonly(*random_oracle, false),
         AccountMeta::new_readonly(sysvar::rent::id(), false),
         AccountMeta::new_readonly(sysvar::clock::id(), false),
         AccountMeta::new_readonly(*whitelisted_creator, false),

--- a/nft-packs/src/processor/init_pack.rs
+++ b/nft-packs/src/processor/init_pack.rs
@@ -46,7 +46,9 @@ pub fn init_pack(
     let mut pack_set = PackSet::unpack_unchecked(&pack_set_account.data.borrow_mut())?;
 
     // make sure that random oracle account is already initialized
-    if random_oracle_account.data.borrow()[0] != randomness_oracle_program::state::AccountType::RandomnessOracle as u8 {
+    if random_oracle_account.data.borrow()[0]
+        != randomness_oracle_program::state::AccountType::RandomnessOracle as u8
+    {
         return Err(ProgramError::UninitializedAccount);
     }
 

--- a/nft-packs/src/processor/init_pack.rs
+++ b/nft-packs/src/processor/init_pack.rs
@@ -26,6 +26,7 @@ pub fn init_pack(
     let pack_set_account = next_account_info(account_info_iter)?;
     let authority_account = next_account_info(account_info_iter)?;
     let store_account = next_account_info(account_info_iter)?;
+    let random_oracle_account = next_account_info(account_info_iter)?;
     let rent_info = next_account_info(account_info_iter)?;
     let rent = &Rent::from_account_info(rent_info)?;
     let clock_info = next_account_info(account_info_iter)?;
@@ -35,6 +36,7 @@ pub fn init_pack(
     assert_rent_exempt(rent, pack_set_account)?;
     assert_signer(authority_account)?;
     assert_owned_by(store_account, &metaplex::id())?;
+    assert_owned_by(random_oracle_account, &randomness_oracle_program::id())?;
     assert_admin_whitelisted(
         store_account,
         whitelisted_creator_account,
@@ -42,6 +44,11 @@ pub fn init_pack(
     )?;
 
     let mut pack_set = PackSet::unpack_unchecked(&pack_set_account.data.borrow_mut())?;
+
+    // make sure that random oracle account is already initialized
+    if random_oracle_account.data.borrow()[0] != randomness_oracle_program::state::AccountType::RandomnessOracle as u8 {
+        return Err(ProgramError::UninitializedAccount);
+    }
 
     if pack_set.is_initialized() {
         return Err(ProgramError::AccountAlreadyInitialized);
@@ -84,6 +91,7 @@ pub fn init_pack(
         allowed_amount_to_redeem: args.allowed_amount_to_redeem,
         redeem_start_date: redeem_start_date,
         redeem_end_date: args.redeem_end_date,
+        random_oracle: *random_oracle_account.key,
     });
 
     pack_set.puff_out_data_fields();

--- a/nft-packs/src/processor/request_card_to_redeem.rs
+++ b/nft-packs/src/processor/request_card_to_redeem.rs
@@ -53,7 +53,6 @@ pub fn request_card_for_redeem(
     let user_token_account = next_account_info(account_info_iter).ok();
 
     // Validate owners
-    assert_owned_by(randomness_oracle_account, &randomness_oracle_program::id())?;
     assert_owned_by(pack_set_account, program_id)?;
     assert_owned_by(store_account, &metaplex::id())?;
     assert_owned_by(edition_mint_account, &spl_token::id())?;
@@ -78,6 +77,7 @@ pub fn request_card_for_redeem(
 
     let pack_set = PackSet::unpack(&pack_set_account.data.borrow())?;
     assert_account_key(store_account, &pack_set.store)?;
+    assert_account_key(randomness_oracle_account, &pack_set.random_oracle)?;
 
     let proving_process_seeds = &[
         ProvingProcess::PREFIX.as_bytes(),

--- a/nft-packs/src/processor/request_card_to_redeem.rs
+++ b/nft-packs/src/processor/request_card_to_redeem.rs
@@ -166,7 +166,8 @@ pub fn request_card_for_redeem(
         return Err(NFTPacksError::UserRedeemedAllCards.into());
     }
 
-    let random_value = get_random_oracle_value(randomness_oracle_account, &proving_process, &clock)?;
+    let random_value =
+        get_random_oracle_value(randomness_oracle_account, &proving_process, &clock)?;
     let weight_sum = if pack_set.distribution_type == PackDistributionType::MaxSupply {
         pack_set.total_editions
     } else {

--- a/nft-packs/src/state/pack_set.rs
+++ b/nft-packs/src/state/pack_set.rs
@@ -89,6 +89,8 @@ pub struct PackSet {
     pub redeem_start_date: u64,
     /// Date when pack set becomes inactive
     pub redeem_end_date: Option<u64>,
+    /// Random oracle
+    pub random_oracle: Pubkey,
 }
 
 impl PackSet {
@@ -110,6 +112,7 @@ impl PackSet {
         self.allowed_amount_to_redeem = params.allowed_amount_to_redeem;
         self.redeem_start_date = params.redeem_start_date;
         self.redeem_end_date = params.redeem_end_date;
+        self.random_oracle = params.random_oracle;
     }
 
     /// Increase pack cards counter
@@ -264,12 +267,14 @@ pub struct InitPackSetParams {
     pub redeem_start_date: u64,
     /// Redeem end date
     pub redeem_end_date: Option<u64>,
+    /// Random oracle
+    pub random_oracle: Pubkey,
 }
 
 impl Sealed for PackSet {}
 
 impl Pack for PackSet {
-    const LEN: usize = 853;
+    const LEN: usize = 885;
 
     fn pack_into_slice(&self, dst: &mut [u8]) {
         let mut slice = dst;

--- a/nft-packs/src/utils.rs
+++ b/nft-packs/src/utils.rs
@@ -1,6 +1,11 @@
 //! Program utils
 
-use crate::{error::NFTPacksError, math::SafeMath, state::{MAX_LAG_SLOTS, ProvingProcess}};
+use crate::{
+    error::NFTPacksError,
+    math::SafeMath,
+    state::{ProvingProcess, MAX_LAG_SLOTS},
+};
+use borsh::BorshSerialize;
 use solana_program::{
     account_info::AccountInfo,
     clock::Clock,
@@ -14,7 +19,6 @@ use solana_program::{
 };
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
-use borsh::BorshSerialize;
 
 /// Assert uninitialized
 pub fn assert_uninitialized<T: IsInitialized>(account: &T) -> ProgramResult {


### PR DESCRIPTION
## What?
Add random oracle account to pack account

## Why?
There was possibility for users to send any random oracle account to RequestCardToRedeem instruction which means users could create own oracles with any values in it and use them to open a pack

## How?
I added random oracle account to pack account so now admin who creates a pack decides which exactly random oracle he wants users to use

## Tests
I refactored tests as well