### PR TITLE
Fix user redeemed cards check in RequestCardsToRedeem instruction

### DIFF
--- a/nft-packs/src/processor/request_card_to_redeem.rs
+++ b/nft-packs/src/processor/request_card_to_redeem.rs
@@ -161,8 +161,10 @@ pub fn request_card_for_redeem(
         }
     }
 
+    let redeemed_cards: u64 = proving_process.cards_to_redeem.values().map(|i| *i as u64).sum();
+
     // Check if user already get all the card indexes
-    if (proving_process.cards_to_redeem.len() as u32) == pack_set.allowed_amount_to_redeem {
+    if redeemed_cards == pack_set.allowed_amount_to_redeem as u64 {
         return Err(NFTPacksError::UserRedeemedAllCards.into());
     }
 


### PR DESCRIPTION
## What
Fix of redeemed cards amount check in `RequestCardsToRedeem` instruction

## Why
There was a bug when users could redeem more cards than they supposed to redeem. It happened because we checked `BTreeMap` len instead of sum of values

## How
Fix it so now we sum all `BTreeMap` values and compare that value with `allowed_amount_to_redeem` value